### PR TITLE
Update renderer.js to remove warnings from threejs r97

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -42,9 +42,9 @@ module.exports = function(THREE) {
         colors = new Float32Array(colors);
 
         var geometry = new THREE.BufferGeometry();
-        geometry.addAttribute('index', new THREE.BufferAttribute(indices, 1));
-        geometry.addAttribute('position', new THREE.BufferAttribute(positions, 3));
-        geometry.addAttribute('color', new THREE.BufferAttribute(colors, 3));
+        geometry.setIndex(new THREE.BufferAttribute(indices, 1, false))
+        geometry.addAttribute('position', new THREE.BufferAttribute(positions, 3, false));
+        geometry.addAttribute('color', new THREE.BufferAttribute(colors, 3, false));
         geometry.computeBoundingSphere();
         return geometry;
     }


### PR DESCRIPTION
1. use setIndex for index buffer
2. THREE.BufferAttribute now accept one more argument (ref: https://threejs.org/docs/index.html#api/en/core/BufferAttribute)